### PR TITLE
Fix bug: no error message shown when deleting exercise in regime with duplicate index

### DIFF
--- a/src/main/java/seedu/exercise/commons/core/index/Index.java
+++ b/src/main/java/seedu/exercise/commons/core/index/Index.java
@@ -51,4 +51,9 @@ public class Index {
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return ((Integer) zeroBasedIndex).hashCode();
+    }
 }

--- a/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
@@ -10,7 +10,6 @@ import static seedu.exercise.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.exercise.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.exercise.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 

--- a/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
@@ -166,12 +166,7 @@ public class AddRegimeCommand extends AddCommand implements PayloadCarrierComman
      * @throws CommandException If a duplicate index is found
      */
     private void checkDuplicateIndexes(List<Index> indexes) throws CommandException {
-        List<Integer> intIndexes = new ArrayList<>();
-        for (Index i : indexes) {
-            intIndexes.add(i.getZeroBased());
-        }
-
-        HashSet<Integer> set = new HashSet<>(intIndexes);
+        HashSet<Index> set = new HashSet<>(indexes);
         if (set.size() < indexes.size()) {
             throw new CommandException(MESSAGE_DUPLICATE_INDEX);
         }

--- a/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/AddRegimeCommand.java
@@ -10,6 +10,7 @@ import static seedu.exercise.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.exercise.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.exercise.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -62,7 +63,7 @@ public class AddRegimeCommand extends AddCommand implements PayloadCarrierComman
         requireNonNull(model);
 
         List<Exercise> lastShownList = model.getFilteredExerciseList();
-        checkDuplicateIndexes();
+        checkDuplicateIndexes(toAddIndexes);
         checkValidIndexes(toAddIndexes, lastShownList);
 
         CommandResult commandResult;
@@ -164,9 +165,14 @@ public class AddRegimeCommand extends AddCommand implements PayloadCarrierComman
      *
      * @throws CommandException If a duplicate index is found
      */
-    private void checkDuplicateIndexes() throws CommandException {
-        HashSet<Index> indexesSet = new HashSet<>(toAddIndexes);
-        if (indexesSet.size() < toAddIndexes.size()) {
+    private void checkDuplicateIndexes(List<Index> indexes) throws CommandException {
+        List<Integer> intIndexes = new ArrayList<>();
+        for (Index i : indexes) {
+            intIndexes.add(i.getZeroBased());
+        }
+
+        HashSet<Integer> set = new HashSet<>(intIndexes);
+        if (set.size() < indexes.size()) {
             throw new CommandException(MESSAGE_DUPLICATE_INDEX);
         }
     }

--- a/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
@@ -6,7 +6,6 @@ import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_EDITED_RE
 import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_IS_REGIME_EDITED;
 import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_ORIGINAL_REGIME;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 

--- a/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
@@ -135,12 +135,7 @@ public class DeleteRegimeCommand extends DeleteCommand implements PayloadCarrier
      * @throws CommandException If a duplicate index is found
      */
     private void checkDuplicateIndexes(List<Index> indexes) throws CommandException {
-        List<Integer> intIndexes = new ArrayList<>();
-        for (Index i : indexes) {
-            intIndexes.add(i.getZeroBased());
-        }
-
-        HashSet<Integer> set = new HashSet<>(intIndexes);
+        HashSet<Index> set = new HashSet<>(indexes);
         if (set.size() < indexes.size()) {
             throw new CommandException(MESSAGE_DUPLICATE_INDEX);
         }

--- a/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/DeleteRegimeCommand.java
@@ -6,6 +6,8 @@ import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_EDITED_RE
 import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_IS_REGIME_EDITED;
 import static seedu.exercise.logic.commands.events.EditRegimeEvent.KEY_ORIGINAL_REGIME;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import seedu.exercise.commons.core.Messages;
@@ -27,6 +29,7 @@ public class DeleteRegimeCommand extends DeleteCommand implements PayloadCarrier
     public static final String MESSAGE_DELETE_REGIME_SUCCESS = "Deleted Regime: %1$s\n%2$s";
     public static final String MESSAGE_REGIME_DOES_NOT_EXIST = "No such regime in regime book.";
     public static final String MESSAGE_DELETE_EXERCISE_IN_REGIME_SUCCESS = "Deleted exercises in regime.";
+    public static final String MESSAGE_DUPLICATE_INDEX = "There is duplicate index.";
     public static final String RESOURCE_TYPE = "regime";
 
     private final List<Index> indexes;
@@ -85,6 +88,7 @@ public class DeleteRegimeCommand extends DeleteCommand implements PayloadCarrier
         Regime editedRegime = originalRegime.deepCopy();
         List<Exercise> currentExerciseList = originalRegime.getRegimeExercises().asUnmodifiableObservableList();
         checkValidIndexes(indexes, currentExerciseList);
+        checkDuplicateIndexes(indexes);
 
         for (Index targetIndex : indexes) {
             Exercise exerciseToDelete = currentExerciseList.get(targetIndex.getZeroBased());
@@ -122,6 +126,23 @@ public class DeleteRegimeCommand extends DeleteCommand implements PayloadCarrier
             if (targetIndex.getZeroBased() >= exerciseList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_EXERCISE_DISPLAYED_INDEX);
             }
+        }
+    }
+
+    /**
+     * Checks whether the given indexes contain duplicates.
+     *
+     * @throws CommandException If a duplicate index is found
+     */
+    private void checkDuplicateIndexes(List<Index> indexes) throws CommandException {
+        List<Integer> intIndexes = new ArrayList<>();
+        for (Index i : indexes) {
+            intIndexes.add(i.getZeroBased());
+        }
+
+        HashSet<Integer> set = new HashSet<>(intIndexes);
+        if (set.size() < indexes.size()) {
+            throw new CommandException(MESSAGE_DUPLICATE_INDEX);
         }
     }
 


### PR DESCRIPTION
I have changed the HashSet in `AddRegimeCommand` to integer because if hash `Index`, need to write `hashCode()` in `Index`.