### PR TITLE
Fix resolve window bug

### DIFF
--- a/src/main/java/seedu/exercise/logic/commands/ResolveCommand.java
+++ b/src/main/java/seedu/exercise/logic/commands/ResolveCommand.java
@@ -46,6 +46,9 @@ public class ResolveCommand extends Command {
     public static final String MESSAGE_DUPLICATE_NAME = "Regime name %1$s already exists. Try another name";
     public static final String MESSAGE_INVALID_NAME = "Regime name is neither the scheduled regime"
             + " or the conflicting regime";
+    public static final String MESSAGE_DUPLICATE_EXERCISE_SELECTED =
+            "You have selected some exercises that are the same from both schedules.\n"
+            + "You only have to select one of them.";
 
     private Name regimeName;
     private Conflict conflict;
@@ -73,6 +76,8 @@ public class ResolveCommand extends Command {
         } else {
             checkNameIsFromConflictingSchedules();
         }
+
+        checkSelectedIndexesDoNotHaveDuplicatesFromModel(model);
 
         resolveConflict(model);
         return new CommandResult(String.format(MESSAGE_SUCCESS,
@@ -122,6 +127,12 @@ public class ResolveCommand extends Command {
     private void checkIfProgramStateIsValid() throws CommandException {
         if (MainApp.getState() != State.IN_CONFLICT) {
             throw new CommandException(String.format(MESSAGE_INVALID_CONTEXT, getClass().getSimpleName()));
+        }
+    }
+
+    private void checkSelectedIndexesDoNotHaveDuplicatesFromModel(Model model) throws CommandException {
+        if (model.isSelectedIndexesFromRegimeDuplicate(indexToTakeFromSchedule, indexToTakeFromConflict)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EXERCISE_SELECTED);
         }
     }
 

--- a/src/main/java/seedu/exercise/model/Model.java
+++ b/src/main/java/seedu/exercise/model/Model.java
@@ -223,6 +223,13 @@ public interface Model {
     void setConflict(Conflict conflict);
 
     /**
+     * Checks if the indexes from scheduled and conflict regimes are duplicates.
+     *
+     * The state of the program must be {@link State#IN_CONFLICT} before calling this method.
+     */
+    boolean isSelectedIndexesFromRegimeDuplicate(List<Index> scheduledIndex, List<Index> conflictingIndex);
+
+    /**
      * Returns the {@code PropertyBook} object that is contained in {@code Model}.
      */
     PropertyBook getPropertyBook();

--- a/src/main/java/seedu/exercise/model/ModelManager.java
+++ b/src/main/java/seedu/exercise/model/ModelManager.java
@@ -286,7 +286,7 @@ public class ModelManager implements Model {
         requireAllNonNull(scheduledIndex, conflictingIndex);
         requireNonNull(conflict);
 
-        return isIndexesForRegimeDupliate(scheduledIndex, conflictingIndex);
+        return isIndexesForRegimeDuplicate(scheduledIndex, conflictingIndex);
     }
 
     //=========== Filtered Exercise List Accessors =============================================================
@@ -452,7 +452,10 @@ public class ModelManager implements Model {
         return uniqueResolveList;
     }
 
-    private boolean isIndexesForRegimeDupliate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
+    /**
+     * Checks if the provided indexes have some duplicate exercises they are referring to
+     */
+    private boolean isIndexesForRegimeDuplicate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
         UniqueResourceList<Exercise> listToAdd = new UniqueResourceList<>();
         List<Exercise> scheduledExercises = conflict
                 .getScheduledRegime().getRegimeExercises().getAllResourcesIndex(scheduledIndex);

--- a/src/main/java/seedu/exercise/model/ModelManager.java
+++ b/src/main/java/seedu/exercise/model/ModelManager.java
@@ -280,6 +280,15 @@ public class ModelManager implements Model {
         this.conflict = conflict;
     }
 
+    @Override
+    public boolean isSelectedIndexesFromRegimeDuplicate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
+        requireMainAppState(State.IN_CONFLICT);
+        requireAllNonNull(scheduledIndex, conflictingIndex);
+        requireNonNull(conflict);
+
+        return isIndexesForRegimeDupliate(scheduledIndex, conflictingIndex);
+    }
+
     //=========== Filtered Exercise List Accessors =============================================================
 
     /**
@@ -441,6 +450,22 @@ public class ModelManager implements Model {
         UniqueResourceList<Exercise> uniqueResolveList = new UniqueResourceList<>();
         uniqueResolveList.setAll(resolvedExercises);
         return uniqueResolveList;
+    }
+
+    private boolean isIndexesForRegimeDupliate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
+        UniqueResourceList<Exercise> listToAdd = new UniqueResourceList<>();
+        List<Exercise> scheduledExercises = conflict
+                .getScheduledRegime().getRegimeExercises().getAllResourcesIndex(scheduledIndex);
+        List<Exercise> conflictExercises = conflict
+                .getConflictingRegime().getRegimeExercises().getAllResourcesIndex(conflictingIndex);
+        listToAdd.setAll(scheduledExercises);
+        for (Exercise conflicted : conflictExercises) {
+            if (listToAdd.contains(conflicted)) {
+                return true;
+            }
+            listToAdd.add(conflicted);
+        }
+        return false;
     }
 
     private Schedule getResolvedSchedule(Name regimeName, UniqueResourceList<Exercise> exerciseList) {

--- a/src/test/java/seedu/exercise/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/exercise/logic/commands/ModelStub.java
@@ -218,6 +218,11 @@ class ModelStub implements Model {
         throw new AssertionError("This method should not be called.");
     }
 
+    @Override
+    public boolean isSelectedIndexesFromRegimeDuplicate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
+        throw new AssertionError("This method should not be called.");
+    }
+
     //=======================suggest================================================================================
 
     @Override

--- a/src/test/java/seedu/exercise/logic/commands/ResolveCommandTest.java
+++ b/src/test/java/seedu/exercise/logic/commands/ResolveCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.exercise.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.exercise.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.exercise.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.exercise.testutil.Assert.assertThrows;
 
@@ -54,7 +55,7 @@ public class ResolveCommandTest {
     private final ResolveCommand validResolveCommandWithNonEmptyIndexesDifferentName = new ResolveCommand(
             new Name(TypicalRegime.VALID_REGIME_NAME_CHEST),
             Arrays.asList(TypicalIndexes.INDEX_ONE_BASED_FIRST),
-            new ArrayList<>());
+            Arrays.asList(TypicalIndexes.INDEX_ONE_BASED_FIRST));
     private final ResolveCommand validResolveCommandWithOutOfBoundIndexes = new ResolveCommand(
             new Name(TypicalRegime.VALID_REGIME_NAME_CARDIO),
             Arrays.asList(TypicalIndexes.INDEX_VERY_LARGE_NUMBER),
@@ -165,6 +166,17 @@ public class ResolveCommandTest {
                 model, expectedMessage);
     }
 
+    @Test
+    public void execute_duplicateExerciseSelectedFromIndex_throwsCommandException() {
+        //Special conflict for testing duplcaite exercises from conflict
+        model.setConflict(TypicalConflict.VALID_CONFLICT_WITH_DUPLICATE_EXERCISES);
+        String expectedMessage = String.format(ResolveCommand.MESSAGE_DUPLICATE_EXERCISE_SELECTED);
+        Model expectedModel = deepCopyModel();
+
+        assertCommandFailure(validResolveCommandWithNonEmptyIndexesDifferentName,
+                model, expectedMessage);
+    }
+
     private Model deepCopyModel() {
         return new ModelManager(new ReadOnlyResourceBook<>(), model.getAllRegimeData(),
                 new ReadOnlyResourceBook<>(), model.getAllScheduleData(), new UserPrefs(),
@@ -228,6 +240,11 @@ public class ResolveCommandTest {
         @Override
         public void resolveConflict(Name regimeName, List<Index> indexFromSchedule, List<Index> indexFromConflict) {
 
+        }
+
+        @Override
+        public boolean isSelectedIndexesFromRegimeDuplicate(List<Index> scheduledIndex, List<Index> conflictingIndex) {
+            return false;
         }
     }
 }

--- a/src/test/java/seedu/exercise/testutil/typicalutil/TypicalConflict.java
+++ b/src/test/java/seedu/exercise/testutil/typicalutil/TypicalConflict.java
@@ -12,4 +12,9 @@ public class TypicalConflict {
             .withScheduled(TypicalSchedule.VALID_SCHEDULE_CARDIO_DATE)
             .withConflict(TypicalSchedule.VALID_SCHEDULE_LEG_DATE)
             .build();
+
+    public static final Conflict VALID_CONFLICT_WITH_DUPLICATE_EXERCISES = new ConflictBuilder()
+            .withScheduled(TypicalSchedule.VALID_SCHEDULE_CARDIO_DATE)
+            .withConflict(TypicalSchedule.VALID_SCHEDULE_CARDIO_DATE)
+            .build();
 }


### PR DESCRIPTION
Resolve command broke when there was duplicate exercise from both regimes being selected. It is now fixed to show a message prompting user to select only one of the exercise